### PR TITLE
Upgraded to lastest stable releases of ember (1.13.3) and ember-cli (1.13.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 ---
 language: node_js
+node_js:
+  - "0.12"
 
 sudo: false
 
@@ -8,6 +10,7 @@ cache:
     - node_modules
 
 before_install:
+  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
 
@@ -16,6 +19,6 @@ install:
   - npm install
   - bower install
   - ember g photoswipe
-
+  
 script:
   - npm test

--- a/addon/components/photo-swipe.js
+++ b/addon/components/photo-swipe.js
@@ -9,16 +9,18 @@ export default Em.Component.extend({
 
   onInsert: Em.on('didInsertElement', function() {
 
-    this.set('pswpEl', this.$('.pswp')[0]);
-    this.set('pswpTheme', PhotoSwipeUI_Default);
+    Em.run.scheduleOnce('afterRender', this, function() {
+      this.set('pswpEl', this.$('.pswp')[0]);
+      this.set('pswpTheme', PhotoSwipeUI_Default);
 
-    this._buildOptions();
+      this._buildOptions();
 
-    // when passing an array of items, we don't need a block
-    if (this.get('items')) {
-      return this._initItemGallery();
-    }
-    return this._calculateItems();
+      // when passing an array of items, we don't need a block
+      if (this.get('items')) {
+        return this._initItemGallery();
+      }
+      return this._calculateItems();
+    });
   }),
 
   _buildOptions: function(getThumbBoundsFn) {
@@ -53,17 +55,17 @@ export default Em.Component.extend({
     });
   },
 
-  itemObserver: function(){
+  itemObserver: Em.observer('items', function(){
     var component = this;
     component._initItemGallery();
-  }.observes('items'),
+  }),
 
   click: function(evt) {
 
     var aElement = this.$(evt.target).parent();
     var index    = this.$("a.photo-item").index( aElement );
 
-    if (Em.isEmpty(this.get('template')) || !aElement.is('a')) { return; }
+    if (!aElement.is('a')) { return; }
 
     evt.preventDefault();
 

--- a/bower.json
+++ b/bower.json
@@ -1,18 +1,17 @@
 {
   "name": "ember-cli-photoswipe",
   "dependencies": {
-    "handlebars": "~1.3.0",
-    "jquery": "^1.11.1",
-    "ember": "1.8.1",
-    "ember-data": "1.0.0-beta.12",
-    "ember-resolver": "~0.1.11",
-    "loader.js": "ember-cli/loader.js#1.0.1",
+    "ember": "1.13.3",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
-    "ember-qunit": "0.1.8",
-    "ember-qunit-notifications": "0.0.4",
-    "qunit": "~1.15.0",
+    "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
+    "ember-data": "1.13.5",
+    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
+    "ember-qunit": "0.4.1",
+    "ember-qunit-notifications": "0.0.7",
+    "ember-resolver": "~0.1.18",
+    "jquery": "^1.11.1",
+    "loader.js": "ember-cli/loader.js#3.2.0",
+    "qunit": "~1.17.1",
     "photoswipe": "4.0.6"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,0 +1,35 @@
+module.exports = {
+  scenarios: [
+    {
+      name: 'default',
+      dependencies: { }
+    },
+    {
+      name: 'ember-release',
+      dependencies: {
+        'ember': 'components/ember#release'
+      },
+      resolutions: {
+        'ember': 'release'
+      }
+    },
+    {
+      name: 'ember-beta',
+      dependencies: {
+        'ember': 'components/ember#beta'
+      },
+      resolutions: {
+        'ember': 'beta'
+      }
+    },
+    {
+      name: 'ember-canary',
+      dependencies: {
+        'ember': 'components/ember#canary'
+      },
+      resolutions: {
+        'ember': 'canary'
+      }
+    }
+  ]
+};

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,0 +1,17 @@
+/* global require, module */
+var EmberApp = require('ember-cli/lib/broccoli/ember-addon');
+
+module.exports = function(defaults) {
+  var app = new EmberApp(defaults, {
+    // Add options here
+  });
+
+  /*
+    This build file specifes the options for the dummy test app of this
+    addon, located in `/tests/dummy`
+    This build file does *not* influence how the addon or the app using it
+    behave. You most likely want to be modifying `./index.js` or app's build file
+  */
+
+  return app.toTree();
+};

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 
 var fs   = require('fs');
 var path = require('path');
+var Funnel = require('broccoli-funnel');
 
 module.exports = {
   name: 'ember-cli-photoswipe',
@@ -26,7 +27,7 @@ module.exports = {
 
   treeForPublic: function() {
     var svgPath = path.join(this.app.bowerDirectory, 'photoswipe', 'dist', 'default-skin');
-    var publicTree = this.pickFiles(this.treeGenerator(svgPath), {
+    var publicTree = new Funnel(this.treeGenerator(svgPath), {
       srcDir: '/',
       destDir: '/assets'
     });

--- a/package.json
+++ b/package.json
@@ -18,22 +18,30 @@
   "author": "Daniel Ochoa <dannytenaglias@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "chalk": "^0.5.1"
-    },
+    "ember-cli-babel": "^5.0.0",
+    "chalk": "^1.1.0"
+  },
   "devDependencies": {
-    "broccoli-asset-rev": "^2.0.0",
-    "broccoli-ember-hbs-template-compiler": "^1.6.1",
+    "broccoli-asset-rev": "^2.0.2",
+    "broccoli-funnel": "^0.2.3",
+    "ember-cli": "1.13.1",
+    "ember-cli-app-version": "0.4.0",
+    "ember-cli-dependency-checker": "^1.0.0",
     "ember-cli-github-pages": "0.0.2",
-    "ember-cli": "0.1.7",
-    "ember-cli-dependency-checker": "0.0.7",
-    "ember-cli-6to5": "0.2.1",
-    "ember-cli-ic-ajax": "0.1.1",
+    "ember-cli-htmlbars": "0.7.9",
+    "ember-cli-htmlbars-inline-precompile": "^0.1.1",
+    "ember-cli-ic-ajax": "0.2.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.1.2",
-    "ember-data": "1.0.0-beta.12",
-    "ember-export-application-global": "^1.0.0",
-    "express": "^4.8.5",
-    "glob": "^4.0.5"
+    "ember-cli-qunit": "0.3.15",
+    "ember-cli-release": "0.2.3",
+    "ember-cli-uglify": "^1.0.1",
+    "ember-data": "1.13.5",
+    "ember-disable-prototype-extensions": "^1.0.0",
+    "ember-disable-proxy-controllers": "^1.0.0",
+    "ember-export-application-global": "^1.0.2",
+    "ember-try": "0.0.6",
+    "express": "^4.13.1",
+    "mkdirp": "^0.5.1"
   },
   "keywords": [
     "ember-addon",

--- a/testem.json
+++ b/testem.json
@@ -1,6 +1,7 @@
 {
   "framework": "qunit",
-  "test_page": "tests/index.html",
+  "test_page": "tests/index.html?hidepassed",
+  "disable_watching": true,
   "launch_in_ci": [
     "PhantomJS"
   ],

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -3,9 +3,11 @@ import Resolver from 'ember/resolver';
 import loadInitializers from 'ember/load-initializers';
 import config from './config/environment';
 
+var App;
+
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
-var App = Ember.Application.extend({
+App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver: Resolver

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -12,10 +12,10 @@
 
 {{#photo-swipe options=psTwoOpts}}
 
-  {{#each img in model}}
-    <a {{bind-attr href="img.href" data-width="img.width"
-      data-height="img.height"}}>
-      <img class="thumb" {{bind-attr src="img.href" alt="img.alt"}}>
+  {{#each model as |img|}}
+    <a class="photo-item" href={{img.href}} data-width={{img.width}}
+      data-height={{img.height}}>
+      <img class="thumb" src={{img.href}} alt={{img.alt}}>
     </a>
   {{/each}}
 

--- a/tests/dummy/public/crossdomain.xml
+++ b/tests/dummy/public/crossdomain.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
 <!DOCTYPE cross-domain-policy SYSTEM "http://www.adobe.com/xml/dtds/cross-domain-policy.dtd">
 <cross-domain-policy>
-    <!-- Read this: www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html -->
+  <!-- Read this: www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html -->
 
-    <!-- Most restrictive policy: -->
-    <site-control permitted-cross-domain-policies="none"/>
+  <!-- Most restrictive policy: -->
+  <site-control permitted-cross-domain-policies="none"/>
 
-    <!-- Least restrictive policy: -->
-    <!--
-    <site-control permitted-cross-domain-policies="all"/>
-    <allow-access-from domain="*" to-ports="*" secure="false"/>
-    <allow-http-request-headers-from domain="*" headers="*" secure="false"/>
-    -->
+  <!-- Least restrictive policy: -->
+  <!--
+  <site-control permitted-cross-domain-policies="all"/>
+  <allow-access-from domain="*" to-ports="*" secure="false"/>
+  <allow-http-request-headers-from domain="*" headers="*" secure="false"/>
+  -->
 </cross-domain-policy>

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import Application from '../../app';
-import Router from '../../router';
 import config from '../../config/environment';
 
 export default function startApp(attrs) {


### PR DESCRIPTION
I was blocked by the ['Cannot convert a Symbol value to a string'](https://github.com/poetic/ember-cli-photoswipe/issues/7) issue when trying to build this project. The suggested workarounds ("rimraf": "2.2.8", "glob": "4.0.5", plus removing the node_modules directory and running npm cache clean) did not resolve the issue.

Updating the project to use the latest versions of ember and ember-cli seemed to do the trick. Thought I'd pass the work back to you in case you'd like to merge it in.

All tests are passing. No errors or deprecation warnings (for me) when using the component.
