### PR TITLE
broccoli-funnel should be a dependency (not devDependency)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
   "author": "Daniel Ochoa <dannytenaglias@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "ember-cli-babel": "^5.0.0"
+    "ember-cli-babel": "^5.0.0",
+    "broccoli-funnel": "^0.2.3"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",
-    "broccoli-funnel": "^0.2.3",
     "ember-cli": "1.13.1",
     "ember-cli-app-version": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.0",


### PR DESCRIPTION
fixes a bug I introduced in https://github.com/poetic/ember-cli-photoswipe/pull/19
