### PR TITLE
Eliminate the custom photoswipe build

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,7 @@ run the generator.
 
 ###### Ember-cli < 0.1.5
 For versions under 0.1.5 you need to run `npm install ember-cli-photoswipe
---save-dev` and then run `ember g photoswipe` in your project.
-
-###### IMPORTANT!
-You must run `ember g photoswipe` whenever your `bower_components` gets cleared, typically in CI environments and fresh clones.
-This is because the addon modifies the content of `bower_components/photoswipe`, and it must be re-done after it was reset. You might also want to add the above command into your `postinstall` hook.
+--save-dev`.
 
 ## Running
 

--- a/blueprints/photoswipe/index.js
+++ b/blueprints/photoswipe/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var fs    = require('fs');
-var chalk = require('chalk');
 
 var PHOTOSWIPE_VERSION = '4.0.6';
 
@@ -12,54 +11,7 @@ module.exports = {
   normalizeEntityName: function() {/* generator with no args */},
 
   afterInstall: function(options) {
-    return this.addBowerPackageToProject('photoswipe', PHOTOSWIPE_VERSION)
-      .then(this.buildPhotoswipeFromSource.bind(this, options));
-  },
-
-  buildPhotoswipeFromSource: function(options) {
-    // we need to make a build without the history module.
-    var fsDir = options.project.bowerDirectory  + '/photoswipe';
-
-    if (!fs.existsSync(fsDir)) {
-      var msg = 'photoswipe was not found on the bower_components directory. ';
-      msg    += 'Please run `bower install --save photoswipe#' + PHOTOSWIPE_VERSION + '` manually first.';
-      throw new Error(msg);
-    }
-
-    var fsFile   = fsDir + '/dist/photoswipe-ember.js';
-    var srcFiles = [
-      'framework-bridge',
-      'core',
-      'show-hide-transition',
-      'items-controller',
-      'tap',
-      'desktop-zoom',
-      'gestures'
-      //'history'
-    ];
-    var newContents = "(function (root, factory) { \n"+
-      "\tif (typeof define === 'function' && define.amd) {\n" +
-        "\t\tdefine(factory);\n" +
-      "\t} else if (typeof exports === 'object') {\n" +
-        "\t\tmodule.exports = factory();\n" +
-      "\t} else {\n" +
-        "\t\troot.PhotoSwipe = factory();\n" +
-      "\t}\n" +
-    "})(this, function () {\n\n" +
-      "\t'use strict';\n"+
-      "\tvar PhotoSwipe = function(template, UiClass, items, options){\n";
-
-    srcFiles.forEach(function(name) {
-      newContents += fs.readFileSync(fsDir + '/src/js/' + name + '.js');
-    });
-
-    newContents+= "\tframework.extend(self, publicMethods); };\n";
-    newContents+= "\treturn PhotoSwipe;\n";
-    newContents+= "});";
-
-    fs.writeFileSync(fsFile, newContents);
-
-    // done!
-    console.log(chalk.green('\n[ember-cli-photoswipe]: Done!'));
+    return this.addBowerPackageToProject('photoswipe', PHOTOSWIPE_VERSION);
   }
+
 };

--- a/index.js
+++ b/index.js
@@ -12,15 +12,9 @@ module.exports = {
     this.app  = app;
     var psDir = app.bowerDirectory + '/photoswipe';
 
-    if (!fs.existsSync(psDir + '/dist/photoswipe-ember.js')) {
-      var msg = '[ember-cli-photoswipe]: You need to run ember g photoswipe to ';
-      msg += 'install required dependencies for this addon.';
-      throw new Error(msg);
-    }
-
     app.import(psDir + '/dist/photoswipe.css');
     app.import(psDir + '/dist/default-skin/default-skin.css');
-    app.import(psDir + '/dist/photoswipe-ember.js');
+    app.import(psDir + '/dist/photoswipe.js');
     app.import(psDir + '/dist/photoswipe-ui-default.min.js');
     app.import(psDir + '/dist/default-skin/default-skin.svg');
   },

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   "author": "Daniel Ochoa <dannytenaglias@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "ember-cli-babel": "^5.0.0",
-    "chalk": "^1.1.0"
+    "ember-cli-babel": "^5.0.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",


### PR DESCRIPTION
As far as I can tell, the custom build of photoswipe is not needed. Photoswipe is already set up to leave out the history module when 'history:false' is passed as an option (which ember-cli-photoswipe already does in addon/components/photo-swipe.js).

If this change looks good to you, can we get an ember-cli-photoswipe release with this and the other changes that have been merged in to master? 
