### PR TITLE
Replace 'click' to launch photo with ember action. Closes #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,8 @@ Ember-cli Addon adaptation of the popular photo gallery library
 ## Usage
 
 ```html
-{{#photo-swipe}}
-  <a class="photo-item" href="http://placekitten.com/g/600/400" data-width="600" data-height="400">
-    <img src="http://placekitten.com/g/300/200" alt="kitty!">
-  </a>
+{{#photo-swipe items=model as |img|}}
+    <img class="thumb" src={{img.src}} alt={{img.title}}>
 {{/photo-swipe}}
 ```
 
@@ -17,10 +15,7 @@ By wrapping your gallery in the component, the addon will take care of
 instantiating Photoswipe for you and for calculating the thumbnail bounds so
 you get the nice zoom in/out animations right out of the box. Easy, right?
 
-Notice that you need to pass the attributes of `data-width` and `data-height`
-to the `<a>` element in order for it to animate. This also works by using an `{{#each}}`
-block to populate your thumbnails. See `tests/dummy/app/templates/application.hbs`
-as an example of this.
+See `tests/dummy/app/templates/application.hbs` as an example of this.
 
 If you want to instanciate a Photoswipe gallery from an action instead of a
 thumbnail, you can also do the following:

--- a/addon/components/photo-swipe.js
+++ b/addon/components/photo-swipe.js
@@ -15,11 +15,20 @@ export default Em.Component.extend({
 
       this._buildOptions();
 
-      // when passing an array of items, we don't need a block
+      /**
+       * DEPRECATED
+       * 
+       * Code exists for backward compatability of block usage 
+       * up to ember-cli-photoswipe versions 1.0.1. 
+       */
       if (this.get('items')) {
         return this._initItemGallery();
       }
+      console.log("WARNING: See https://github.com/poetic/ember-cli-photoswipe#usage");
       return this._calculateItems();
+      /**
+       * END DEPRECATED
+       */
     });
   }),
 
@@ -59,8 +68,18 @@ export default Em.Component.extend({
     var component = this;
     component._initItemGallery();
   }),
-
+  
+  /**
+   * DEPRECATED
+   * 
+   * Code exists for backward compatability of block usage 
+   * up to ember-cli-photoswipe versions 1.0.1. 
+   */  
   click: function(evt) {
+
+    if (this.get('items')) {
+      return; // ignore - not using deprecated block form
+    }
 
     var aElement = this.$(evt.target).parent();
     var index    = this.$("a.photo-item").index( aElement );
@@ -81,7 +100,10 @@ export default Em.Component.extend({
     );
     this.set('gallery', pSwipe);
     this.get('gallery').init();
-  },
+  }, 
+  /**
+   * END DEPRECATED
+   */   
 
   _getBounds: function(i) {
     var img      = this.$('img').get(i),
@@ -90,6 +112,31 @@ export default Em.Component.extend({
     return {x: position.left, y: position.top, w: width};
   },
 
+  actions: {
+    launchGallery(item) {
+      this._buildOptions(this._getBounds.bind(this));
+      if (item !== undefined) {
+        var index = this.get('items').indexOf(item);
+        this.set('options.index', index);
+      }
+      var pSwipe = new PhotoSwipe(
+        this.get('pswpEl'),
+        this.get('pswpTheme'),
+        this.get('items'),
+        this.get('options')
+      );
+      this.set('gallery', pSwipe);
+      this.get('gallery').init();
+    }
+  },
+
+
+  /**
+   * DEPRECATED
+   * 
+   * Code exists for backward compatability of block usage 
+   * up to ember-cli-photoswipe versions 1.0.1. 
+   */  
   _calculateItems: function() {
     var items           = this.$().find('a');
     var calculatedItems = Em.A(items).map(function(i, item) {
@@ -102,5 +149,9 @@ export default Em.Component.extend({
       };
     });
     this.set('calculatedItems', calculatedItems);
-  }
+  }  
+  /**
+   * END DEPRECATED
+   */      
+
 });

--- a/app/templates/components/photo-swipe.hbs
+++ b/app/templates/components/photo-swipe.hbs
@@ -1,4 +1,15 @@
-{{yield}}
+{{#if hasBlock}}
+  {{#if items}}
+    {{#each items as |item|}}
+      <a {{action 'launchGallery' item}} data-width={{item.w}} data-height={{item.h}}>
+          {{yield item}}
+      </a>
+    {{/each}}
+  {{else}}
+    {{!-- For backward compatability of block usage up to ember-cli-photoswipe versions 1.1.0 --}}
+    {{yield}}
+  {{/if}}
+{{/if}}
 <!-- Root element of PhotoSwipe. Must have class pswp. -->
 <div class="pswp" tabindex="-1" role="dialog" aria-hidden="true">
 

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -4,29 +4,29 @@ export default Ember.Route.extend({
   model: function() {
     return [
       {
-        href: 'http://placekitten.com/g/600/450',
-        width: 600, height: 450,
-        alt: 'Image Description'
+        src: 'http://placekitten.com/g/600/450',
+        w: 600, h: 450,
+        title: 'Image Description'
       },
       {
-        href: 'http://placekitten.com/630/600',
-        width: 630, height: 600,
-        alt: 'kitty'
+        src: 'http://placekitten.com/630/600',
+        w: 630, h: 600,
+        title: 'kitty'
       },
       {
-        href: 'http://placekitten.com/g/450/450',
-        width: 450, height: 450,
-        alt: 'more kitty'
+        src: 'http://placekitten.com/g/450/450',
+        w: 450, h: 450,
+        title: 'more kitty'
       },
       {
-        href: 'http://placekitten.com/g/400/600',
-        width: 400, height: 600,
-        alt: 'more more kitty'
+        src: 'http://placekitten.com/g/400/600',
+        w: 400, h: 600,
+        title: 'more more kitty'
       },
       {
-        href: 'http://placekitten.com/g/500/400',
-        width: 500, height: 400,
-        alt: 'yup... kitty'
+        src: 'http://placekitten.com/g/500/400',
+        w: 500, h: 400,
+        title: 'yup... kitty'
       }
     ];
   }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -10,13 +10,8 @@
 <!-- example 2 -->
 <h3>Example when passing a block</h3>
 
-{{#photo-swipe options=psTwoOpts}}
+{{#photo-swipe options=psTwoOpts items=model as |img|}}
 
-  {{#each model as |img|}}
-    <a class="photo-item" href={{img.href}} data-width={{img.width}}
-      data-height={{img.height}}>
-      <img class="thumb" src={{img.href}} alt={{img.alt}}>
-    </a>
-  {{/each}}
+    <img class="thumb" src={{img.src}} alt={{img.title}}>
 
 {{/photo-swipe}}


### PR DESCRIPTION
Take a look at this one and let me know if you have any concerns. Aside from putting in a true fix for the [element index issue](https://github.com/poetic/ember-cli-photoswipe/issues/11), some benefits are:
- [Less markup](https://github.com/jcowley/ember-cli-photoswipe/tree/replace-click-with-action#usage) for the end user to write 
- No longer requires the user to pass the attributes of data-width and data-height
- Follows the guidelines for [composable components](http://guides.emberjs.com/v1.13.0/components/composing-components/#toc_data-down), which would allow users to insert a component for the thumbnail rather than an <img> tag
- Generally more of an "emberish" approach (action vs a click handler)

Lastly, there's a good chunk of code in addon/components/photo-swipe.js that can be removed with this change. However, I've left it in to support backward compatibility for users who followed the existing guidelines for passing a block to the component. I've [wrapped that code in comments](https://github.com/jcowley/ember-cli-photoswipe/blob/replace-click-with-action/addon/components/photo-swipe.js) indicating this and also added a console.log warning for end users. It could be removed in a later release.
