### PR TITLE
don't add unnecessary files to assets

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,14 +16,14 @@ module.exports = {
     app.import(psDir + '/dist/default-skin/default-skin.css');
     app.import(psDir + '/dist/photoswipe.js');
     app.import(psDir + '/dist/photoswipe-ui-default.min.js');
-    app.import(psDir + '/dist/default-skin/default-skin.svg');
   },
 
   treeForPublic: function() {
     var svgPath = path.join(this.app.bowerDirectory, 'photoswipe', 'dist', 'default-skin');
     var publicTree = new Funnel(this.treeGenerator(svgPath), {
       srcDir: '/',
-      destDir: '/assets'
+      destDir: '/assets',
+      exclude: ['default-skin.css']
     });
     return publicTree;
   }


### PR DESCRIPTION
`assets/photoswipe/dist/default-skin/default-skin.svg` was added to `dist` but is also present at `assets/default-skin.svg`
`assets/default-skin.css` was added to `dist` but is already included in `vendor.css`
