### PR TITLE
Provide a way to pass custom images array and have them yielded

### DIFF
--- a/addon/components/photo-swipe.js
+++ b/addon/components/photo-swipe.js
@@ -5,7 +5,34 @@ import Em from 'ember';
 
 var run = Em.run;
 
+const defaultPropertiesName = {
+  src: 'src',
+  h: 'h',
+  w: 'w',
+  title: 'title'
+};
+
 export default Em.Component.extend({
+
+  didInitAttrs() {
+    const newPropertiesName = this.get('propertiesName') || {};
+    this.set('propertiesName', Em.merge(defaultPropertiesName, newPropertiesName));
+
+    this.set('_internalItems', this._buildInternalItems());
+  },
+
+  _buildInternalItems() {
+    const propertiesName = this.get('propertiesName');
+    const items = this.get('items');
+    return Em.A(items).map((item) => {
+      return {
+        src: Em.get(item, propertiesName.src),
+        h: Em.get(item, propertiesName.h),
+        w: Em.get(item, propertiesName.w),
+        title: Em.get(item, propertiesName.title)
+      };
+    });
+  },
 
   onInsert: Em.on('didInsertElement', function() {
 
@@ -17,11 +44,11 @@ export default Em.Component.extend({
 
       /**
        * DEPRECATED
-       * 
-       * Code exists for backward compatability of block usage 
-       * up to ember-cli-photoswipe versions 1.0.1. 
+       *
+       * Code exists for backward compatability of block usage
+       * up to ember-cli-photoswipe versions 1.0.1.
        */
-      if (this.get('items')) {
+      if (this.get('_internalItems')) {
         return this._initItemGallery();
       }
       console.log("WARNING: See https://github.com/poetic/ember-cli-photoswipe#usage");
@@ -49,7 +76,7 @@ export default Em.Component.extend({
     this.set('gallery', new PhotoSwipe(
       this.get('pswpEl'),
       this.get('pswpTheme'),
-      this.get('items'),
+      this.get('_internalItems'),
       this.get('options')
     ));
     this._reInitOnClose();
@@ -64,20 +91,20 @@ export default Em.Component.extend({
     });
   },
 
-  itemObserver: Em.observer('items', function(){
+  itemObserver: Em.observer('_internalItems', function(){
     var component = this;
     component._initItemGallery();
   }),
-  
+
   /**
    * DEPRECATED
-   * 
-   * Code exists for backward compatability of block usage 
-   * up to ember-cli-photoswipe versions 1.0.1. 
-   */  
+   *
+   * Code exists for backward compatability of block usage
+   * up to ember-cli-photoswipe versions 1.0.1.
+   */
   click: function(evt) {
 
-    if (this.get('items')) {
+    if (this.get('_internalItems')) {
       return; // ignore - not using deprecated block form
     }
 
@@ -100,10 +127,10 @@ export default Em.Component.extend({
     );
     this.set('gallery', pSwipe);
     this.get('gallery').init();
-  }, 
+  },
   /**
    * END DEPRECATED
-   */   
+   */
 
   _getBounds: function(i) {
     var img      = this.$('img').get(i),
@@ -116,13 +143,13 @@ export default Em.Component.extend({
     launchGallery(item) {
       this._buildOptions(this._getBounds.bind(this));
       if (item !== undefined) {
-        var index = this.get('items').indexOf(item);
+        var index = this.get('_internalItems').indexOf(item);
         this.set('options.index', index);
       }
       var pSwipe = new PhotoSwipe(
         this.get('pswpEl'),
         this.get('pswpTheme'),
-        this.get('items'),
+        this.get('_internalItems'),
         this.get('options')
       );
       this.set('gallery', pSwipe);
@@ -133,10 +160,10 @@ export default Em.Component.extend({
 
   /**
    * DEPRECATED
-   * 
-   * Code exists for backward compatability of block usage 
-   * up to ember-cli-photoswipe versions 1.0.1. 
-   */  
+   *
+   * Code exists for backward compatability of block usage
+   * up to ember-cli-photoswipe versions 1.0.1.
+   */
   _calculateItems: function() {
     var items           = this.$().find('a');
     var calculatedItems = Em.A(items).map(function(i, item) {
@@ -149,9 +176,8 @@ export default Em.Component.extend({
       };
     });
     this.set('calculatedItems', calculatedItems);
-  }  
+  }
   /**
    * END DEPRECATED
-   */      
-
+   */
 });

--- a/addon/helpers/object-at.js
+++ b/addon/helpers/object-at.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export function objectAt(params/*, hash*/) {
+  const [array, index] = params;
+
+  return array.objectAt(index);
+}
+
+export default Ember.Helper.helper(objectAt);

--- a/app/helpers/object-at.js
+++ b/app/helpers/object-at.js
@@ -1,0 +1,1 @@
+export { default, objectAt } from 'ember-cli-photoswipe/helpers/object-at';

--- a/app/templates/components/photo-swipe.hbs
+++ b/app/templates/components/photo-swipe.hbs
@@ -1,8 +1,8 @@
 {{#if hasBlock}}
   {{#if items}}
-    {{#each items as |item|}}
+    {{#each _internalItems as |item index|}}
       <a {{action 'launchGallery' item}} data-width={{item.w}} data-height={{item.h}}>
-          {{yield item}}
+          {{yield (object-at items index)}}
       </a>
     {{/each}}
   {{else}}

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -20,6 +20,25 @@ export default Ember.Controller.extend({
     }
   ],
 
+  itemsWithUncommonProp: [
+    {
+      path: 'http://placekitten.com/g/600/400',
+      width: 600,
+      h: 400,
+      title: 'whooa'
+    },
+    {
+      path: 'http://placekitten.com/g/1200/900',
+      width: 1200,
+      h: 900
+    }
+  ],
+
+  newPropertiesName: {
+    src: 'path',
+    w: 'width'
+  },
+
   // actions
   actions: {
     initGallery: function() {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -15,3 +15,12 @@
     <img class="thumb" src={{img.src}} alt={{img.title}}>
 
 {{/photo-swipe}}
+
+<!-- example 2 -->
+<h3>Example when passing a block and images with properties that are not what photo-swipe expects</h3>
+
+{{#photo-swipe options=psTwoOpts items=itemsWithUncommonProp propertiesName=newPropertiesName as |img|}}
+
+    <img class="thumb" src={{img.path}} alt={{img.title}}>
+
+{{/photo-swipe}}

--- a/tests/unit/helpers/object-at-test.js
+++ b/tests/unit/helpers/object-at-test.js
@@ -1,0 +1,14 @@
+import { objectAt } from '../../../helpers/object-at';
+import { module, test } from 'qunit';
+import Ember from "ember";
+
+module('Unit | Helper | object at');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  var array = Ember.A([
+    'foo', 'bar'
+  ]);
+  var result = objectAt([array, 1]);
+  assert.equal(result, 'bar');
+});


### PR DESCRIPTION
This pull request addresses an issue that occured using this component combined with another one.
Given this template

```
{{#photo-swipe items=images as |img|}}
  {{other-component image=img}}
{{/photo-swipe}}
```

the other component requires the image object formatted like this

```
{
  path: 'http://something.foo',
  width: 600,
  // ...
}
```

although photo-swipe component wants the items array made of objects that are directly understandable by photoswipe.js and therefore passed via the `{{yield}}` helper.

This pull request allows passing an array of objects formatted in the way you prefer, you have just to provide the component an hash, mapping the custom property names to the photoswipe.js ones. So with image objects like previous one you have to provide smething like this

```
// in your controller
customPropertiesMap: {
  src: 'path',
  w: 'width'
}

// in your template
{{#photo-swipe items=images propertiesName=customPropertiesMap as |img|}}
  <img src={{img.path}} />
{{/photo-swipe}}
```

in addition the `|img|` block param is exactly what you expect
