### PR TITLE
Deprecate and document

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ember-cli Addon adaptation of the popular photo gallery library
 
 ```html
 {{#photo-swipe items=model as |img|}}
-    <img class="thumb" src={{img.src}} alt={{img.title}}>
+  <img class="thumb" src={{img.src}} alt={{img.title}}>
 {{/photo-swipe}}
 ```
 
@@ -16,6 +16,21 @@ instantiating PhotoSwipe for you and for calculating the thumbnail bounds so
 you get the nice zoom in/out animations right out of the box. Easy, right?
 
 See `tests/dummy/app/templates/application.hbs` as an example of this.
+
+The `items` property is required and an array of objects should be
+passed to it. PhotoSwipe expects these items to have the following structure:
+
+```javascript
+[
+  {
+    src: 'http://placekitten.com/g/600/400',
+    w: 600,
+    h: 400,
+    title: 'whooa',
+    msrc: '(optional) larger image'
+  }
+]
+```
 
 If you want to instantiate a PhotoSwipe gallery from an action instead of a
 thumbnail, you can also do the following:
@@ -39,20 +54,6 @@ This is used to instantiate PhotoSwipe and to interact with the live instance.
 
 Any PhotoSwipe options can be passed to the `options` property of the component.
 For now the history module is disabled since it breaks ember routing.
-
-Finally, the `items` property is required and an array of objects should be
-passed to it. For example:
-
-```javascript
-items = [
-  {
-    src: 'http://placekitten.com/g/600/400',
-    w: 600,
-    h: 400,
-    title: 'whooa'
-  }
-]
-```
 
 More functionality is on the way, this is a work in progress. You can find
 PhotoSwipe documentation [here](http://photoswipe.com/).

--- a/addon/components/photo-swipe.js
+++ b/addon/components/photo-swipe.js
@@ -15,16 +15,16 @@ export default Em.Component.extend({
 
       this._buildOptions();
 
-      /**
-       * DEPRECATED
-       * 
-       * Code exists for backward compatability of block usage 
-       * up to ember-cli-photoswipe versions 1.0.1. 
-       */
       if (this.get('items')) {
         return this._initItemGallery();
       }
-      console.log("WARNING: See https://github.com/poetic/ember-cli-photoswipe#usage");
+
+      /**
+       * DEPRECATED
+       *
+       * Code exists for backward compatibility of block usage
+       * up to ember-cli-photoswipe versions 1.0.1.
+       */
       return this._calculateItems();
       /**
        * END DEPRECATED
@@ -68,13 +68,13 @@ export default Em.Component.extend({
     var component = this;
     component._initItemGallery();
   }),
-  
+
   /**
    * DEPRECATED
-   * 
-   * Code exists for backward compatability of block usage 
-   * up to ember-cli-photoswipe versions 1.0.1. 
-   */  
+   *
+   * Code exists for backward compatibility of block usage
+   * up to ember-cli-photoswipe versions 1.0.1.
+   */
   click: function(evt) {
 
     if (this.get('items')) {
@@ -100,10 +100,10 @@ export default Em.Component.extend({
     );
     this.set('gallery', pSwipe);
     this.get('gallery').init();
-  }, 
+  },
   /**
    * END DEPRECATED
-   */   
+   */
 
   _getBounds: function(i) {
     var img      = this.$('img').get(i),
@@ -133,11 +133,18 @@ export default Em.Component.extend({
 
   /**
    * DEPRECATED
-   * 
-   * Code exists for backward compatability of block usage 
-   * up to ember-cli-photoswipe versions 1.0.1. 
-   */  
+   *
+   * Code exists for backward compatibility of block usage
+   * up to ember-cli-photoswipe versions 1.0.1.
+   */
   _calculateItems: function() {
+    Em.deprecate(
+      "Using ember-cli-photoswipe without an items attribute is deprecated. "+
+      "See https://github.com/poetic/ember-cli-photoswipe#usage",
+      false,
+      {id: 'ember-cli-photoswipe.didInsertElement', until: '1.13'}
+    );
+
     var items           = this.$().find('a');
     var calculatedItems = Em.A(items).map(function(i, item) {
       return {
@@ -149,9 +156,9 @@ export default Em.Component.extend({
       };
     });
     this.set('calculatedItems', calculatedItems);
-  }  
+  }
   /**
    * END DEPRECATED
-   */      
+   */
 
 });

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit": "0.4.1",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.1",
+    "jquery": "1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "qunit": "~1.17.1",
     "photoswipe": "4.1.0"

--- a/tests/acceptance/ember-cli-photoswipe-test.js
+++ b/tests/acceptance/ember-cli-photoswipe-test.js
@@ -16,8 +16,10 @@ test('visiting /', function() {
   visit('/');
 
   andThen(function() {
-    equal(find('button.btn').length, 1, 'Page containts button');
+    equal(find('button.btn').length, 1, 'Page contains button');
     click(find('button.btn'));
+
+    equal(find('img.thumb').length, 2);
   });
 
   andThen(function() {
@@ -30,4 +32,12 @@ test('visiting /', function() {
     click('.pswp__button--close');
   });
 
+  andThen(function() {
+    equal(find('button.change-btn').length, 1, 'Page contains change button');
+    click(find('button.change-btn'));
+  });
+
+  andThen(function() {
+    equal(find('img.thumb').length, 1);
+  });
 });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -6,7 +6,7 @@ export default Ember.Controller.extend({
     index: 1
   },
 
-  items: [
+  items1: [
     {
       src: 'http://placekitten.com/g/600/400',
       w: 600,
@@ -20,10 +20,34 @@ export default Ember.Controller.extend({
     }
   ],
 
+  items2: [
+    {
+      src: 'http://placekitten.com/g/60/40',
+      w: 60,
+      h: 40,
+      title: 'kitties'
+    }
+  ],
+
+  init() {
+    this._super(...arguments);
+    this.set('items', this.get('items1'));
+  },
+
   // actions
   actions: {
-    initGallery: function() {
+    initGallery() {
       this.get('myGallery').init();
+    },
+
+    changeItems() {
+      if (this.get('items') === this.get('items1')) {
+        console.log('changing to 2');
+        this.set('items', this.get('items2'));
+      } else {
+        console.log('changing to 1');
+        this.set('items', this.get('items1'));
+      }
     }
   },
 

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,34 +1,3 @@
 import Ember from 'ember';
 
-export default Ember.Route.extend({
-  model: function() {
-    return [
-      {
-        src: 'http://placekitten.com/g/600/450',
-        w: 600, h: 450,
-        title: 'Image Description'
-      },
-      {
-        src: 'http://placekitten.com/630/600',
-        w: 630, h: 600,
-        title: 'kitty'
-      },
-      {
-        src: 'http://placekitten.com/g/450/450',
-        w: 450, h: 450,
-        title: 'more kitty'
-      },
-      {
-        src: 'http://placekitten.com/g/400/600',
-        w: 400, h: 600,
-        title: 'more more kitty'
-      },
-      {
-        src: 'http://placekitten.com/g/500/400',
-        w: 500, h: 400,
-        title: 'yup... kitty'
-      }
-    ];
-  }
-});
-
+export default Ember.Route.extend();

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -2,6 +2,7 @@
 
 <!-- example 1 -->
 <button class="btn" {{action 'initGallery'}}>Open PhotoSwipe</button>
+<button class="change-btn" {{action 'changeItems'}}>Change Items</button>
 
 {{photo-swipe gallery=myGallery options=psOpts items=items}}
 
@@ -10,7 +11,7 @@
 <!-- example 2 -->
 <h3>Example when passing a block</h3>
 
-{{#photo-swipe options=psTwoOpts items=model as |img|}}
+{{#photo-swipe options=psTwoOpts items=items as |img|}}
 
     <img class="thumb" src={{img.src}} alt={{img.title}}>
 

--- a/tests/unit/components/photo-swipe-test.js
+++ b/tests/unit/components/photo-swipe-test.js
@@ -4,7 +4,9 @@ import {
   test
 } from 'ember-qunit';
 
-moduleForComponent('photo-swipe', 'PhotoSwipeComponent');
+moduleForComponent('photo-swipe', 'PhotoSwipeComponent', {
+  unit: true
+});
 
 test('it renders', function() {
   expect(2);
@@ -13,14 +15,14 @@ test('it renders', function() {
   var component = this.subject();
   equal(component._state, 'preRender');
 
-  // appends the component to the page
-  this.append();
+  // renders the component to the page
+  this.render();
   equal(component._state, 'inDOM');
 });
 
 test('it renders the photoswipe template', function() {
   expect(1);
-  this.append();
+  this.render();
   var component = this.subject();
   var photoswipe = component.$('.pswp');
 
@@ -29,29 +31,36 @@ test('it renders the photoswipe template', function() {
 
 test('the gallery attribute should be empty on insert.', function() {
   expect(1);
-  this.append();
   var component = this.subject();
 
-  equal(component.get('gallery'), undefined, 'should not be set yet.');
+  Ember.run(function () {
+    equal(component.get('gallery'), undefined, 'should not be set yet.');
+  });
 });
 
 test('the gallery attribute should be set when you pass items', function() {
   expect(2);
-  var component = this.subject();
-  component.set('items', [
-    {
-      src: 'http://placekitten.com/g/600/400',
-      w: 600,
-      h: 400,
-      title: 'whooa'
-    },
-    {
-      src: 'http://placekitten.com/g/1200/900',
-      w: 1200,
-      h: 900
-    }
-  ]);
-  this.append();
-  ok(component.get('gallery'));
-  equal(typeof component.get('gallery'), 'object');
+
+  Ember.run(() => {
+    var component = this.subject();
+    component.set('items', [
+      {
+        src: 'http://placekitten.com/g/600/400',
+        w: 600,
+        h: 400,
+        title: 'whooa'
+      },
+      {
+        src: 'http://placekitten.com/g/1200/900',
+        w: 1200,
+        h: 900
+      }
+    ]);
+
+    this.render();
+
+    var gallery = component.get('gallery');
+    ok(gallery);
+    equal(typeof gallery, 'object');
+  });
 });


### PR DESCRIPTION
This branch includes some modernization fixes - notably, it now correctly displays a deprecation warning when the component is used without an `items` attribute. (Ember swallows `console.log` statements from components unless they come via `Ember.deprecate`). It also adds a couple test cases and better documents usage that confused me at first.
