### PR TITLE
FIX: Gallery is not reinitialized when changing routes

### DIFF
--- a/addon/components/photo-swipe.js
+++ b/addon/components/photo-swipe.js
@@ -52,6 +52,7 @@ export default Em.Component.extend({
       this.get('items'),
       this.get('options')
     ));
+    if(this.get('reinit')) this.sendAction('reinit', this.get('gallery'));
     this._reInitOnClose();
   },
 

--- a/addon/components/photo-swipe.js
+++ b/addon/components/photo-swipe.js
@@ -52,7 +52,9 @@ export default Em.Component.extend({
       this.get('items'),
       this.get('options')
     ));
-    if(this.get('reinit')) this.sendAction('reinit', this.get('gallery'));
+    if(this.get('reinit')) {
+      this.sendAction('reinit', this.get('gallery'));
+    }
     this._reInitOnClose();
   },
 

--- a/addon/components/photo-swipe.js
+++ b/addon/components/photo-swipe.js
@@ -52,7 +52,7 @@ export default Em.Component.extend({
       this.get('items'),
       this.get('options')
     ));
-    if(this.get('reinit')) {
+    if (this.get('reinit')) {
       this.sendAction('reinit', this.get('gallery'));
     }
     this._reInitOnClose();

--- a/tests/unit/components/photo-swipe-test.js
+++ b/tests/unit/components/photo-swipe-test.js
@@ -65,7 +65,7 @@ test('the gallery attribute should be set when you pass items', function() {
   });
 });
 
-test('the reinit action is called when the gallery items change', function() {
+test('the reinit action should be called when the gallery items change', function() {
   // reinit will be called 3 times in the test
   // Once when setting the setting the properties
   // Second when you render the Component
@@ -97,5 +97,5 @@ test('the reinit action is called when the gallery items change', function() {
     this.render();
 
     component.set('items', []);
-  })
+  });
 });

--- a/tests/unit/components/photo-swipe-test.js
+++ b/tests/unit/components/photo-swipe-test.js
@@ -64,3 +64,38 @@ test('the gallery attribute should be set when you pass items', function() {
     equal(typeof gallery, 'object');
   });
 });
+
+test('the reinit action is called when the gallery items change', function() {
+  // reinit will be called 3 times in the test
+  // Once when setting the setting the properties
+  // Second when you render the Component
+  // Third when you change the items array
+  expect(6);
+
+  Ember.run(()=> {
+    var component = this.subject();
+    component.setProperties({
+      reinit: function(gallery){
+        ok(gallery);
+        equal(typeof gallery, 'object');
+      },
+      items: [
+        {
+          src: 'http://placekitten.com/g/600/400',
+          w: 600,
+          h: 400,
+          title: 'whooa'
+        },
+        {
+          src: 'http://placekitten.com/g/1200/900',
+          w: 1200,
+          h: 900
+        }
+      ]
+    });
+
+    this.render();
+
+    component.set('items', []);
+  })
+});


### PR DESCRIPTION
## Issue

This PR follows the “data down, actions up” approach to fix the photoswipe gallery not being replaced when you transition between the same routes.

**Current behaviour.**
![old-issue](https://cloud.githubusercontent.com/assets/771903/14412935/659d4c2e-ff64-11e5-8c93-6c62c04a7844.gif)

**Expected (fixed) behaviour.**
![new-fixed](https://cloud.githubusercontent.com/assets/771903/14412938/749159a0-ff64-11e5-9f6c-6ce950747a23.gif)
## Fix

It adds an optional `reinit` action in the component, which is called whenever `_reInitGallery` is ran.
The reinit action passes the newly created photoswipe object as the first parameter.
## Usage:

``` javascript
export default Em.Component.extend({
    someGallery: null,
    items: [
        // Gallery items here
    ],

    actions: {
        replaceGallery(newGallery){
            this.set('someGallery', newGallery);
        }
    }
})
```

``````
{{!-- template file --}}
{{photo-swipe gallery=someGallery items=items reinit=(action 'replaceGallery')}}```
``````
